### PR TITLE
Feat: Allow to create dot files first in Githunb repos

### DIFF
--- a/modules/ostack/vcs_github.tf
+++ b/modules/ostack/vcs_github.tf
@@ -117,6 +117,7 @@ module "vcs_repo_globalconfig_github" {
   branch_status_checks             = each.value.vcs.branch_status_checks
   deploy_keys                      = each.value.vcs.deploy_keys
   description                      = each.value.description
+  dotfiles_first                   = true
   files                            = local.globalconfig_dynamic[each.key].vcs.files
   files_strict                     = local.globalconfig_dynamic[each.key].vcs.files_strict
   has_issues                       = each.value.vcs.repo_enable_issues

--- a/modules/repo-github/_inputs.tf
+++ b/modules/repo-github/_inputs.tf
@@ -236,6 +236,16 @@ variable "files" {
   }
 }
 
+variable "dotfiles_first" {
+  description = "If .* (.github) files at the root of the repo should be added first."
+  type        = bool
+  default     = false
+  validation {
+    error_message = "Variable files cannot be null."
+    condition     = var.dotfiles_first != null
+  }
+}
+
 variable "sensitive_inputs" {
   description = "Values that should be marked as sensitive. Supported by `secrets`, `deploy_keys`."
   type        = map(string)

--- a/modules/repo-github/docs/README.md
+++ b/modules/repo-github/docs/README.md
@@ -26,6 +26,8 @@ No modules.
 | [github_issue_label.labels](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/issue_label) | resource |
 | [github_repository.repo](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_deploy_key.deploy_keys](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
+| [github_repository_file.dotfiles](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [github_repository_file.dotfiles_strict](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.files](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_file.files_strict](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_team_repository.permissions](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
@@ -48,6 +50,7 @@ No modules.
 | <a name="input_branch_status_checks"></a> [branch_status_checks](#input_branch_status_checks) | List of status checks required before merging pull requests. | `list(string)` | `[]` | no |
 | <a name="input_deploy_keys"></a> [deploy_keys](#input_deploy_keys) | Map of repository deploy keys. You can pass sensitive values by setting the `ssh_key` value to `sensitive::key` where `key` refers to a value in `sensitive_inputs`. | <pre>map(object({<br> title = string<br> ssh_key = string<br> read_only = optional(bool)<br> }))</pre> | `{}` | no |
 | <a name="input_description"></a> [description](#input_description) | A description of the repository. | `string` | `null` | no |
+| <a name="input_dotfiles_first"></a> [dotfiles_first](#input_dotfiles_first) | If .\* (.github) files at the root of the repo should be added first. | `bool` | `false` | no |
 | <a name="input_files"></a> [files](#input_files) | Files to add to the repository's default branch. These files can be modified outside of Terraform. | `map(string)` | `{}` | no |
 | <a name="input_files_strict"></a> [files_strict](#input_files_strict) | Files to add to the repository's default branch. These files are tracked by Terraform to make sure their content always matches the configuration. | `map(string)` | `{}` | no |
 | <a name="input_has_issues"></a> [has_issues](#input_has_issues) | Set to `true` to enable the GitHub Issues features on the repository. | `bool` | `true` | no |

--- a/modules/repo-github/files.tf
+++ b/modules/repo-github/files.tf
@@ -1,21 +1,54 @@
 # ---------------------------------------------------------------------------------------------------------------------
 # Computations
 # ---------------------------------------------------------------------------------------------------------------------
-# GitHub does not like empty files
+# GitHub does not like empty files, so make sure no file is empty
 locals {
-  files_strict = { for k, v in var.files_strict :
-    k => v == "" ? " " : v
+  files_strict = { for file_path, file_content in var.files_strict :
+    file_path => file_content == "" ? " " : file_content if !(var.dotfiles_first && can(regex("^\\.", file_path)))
   }
-  files = { for k, v in var.files :
-    k => v == "" ? " " : v
+  files = { for file_path, file_content in var.files :
+    file_path => file_content == "" ? " " : file_content if !(var.dotfiles_first && can(regex("^\\.", file_path)))
+  }
+  dotfiles_strict = { for file_path, file_content in var.files_strict :
+    file_path => file_content == "" ? " " : file_content if var.dotfiles_first && can(regex("^\\.", file_path))
+  }
+  dotfiles = { for file_path, file_content in var.files :
+    file_path => file_content == "" ? " " : file_content if var.dotfiles_first && can(regex("^\\.", file_path))
   }
 }
 # ---------------------------------------------------------------------------------------------------------------------
 # Resources
 # ---------------------------------------------------------------------------------------------------------------------
+resource "github_repository_file" "dotfiles_strict" {
+  for_each = local.dotfiles_strict
+
+  repository          = local.repo.name
+  branch              = local.repo.default_branch
+  file                = each.key
+  content             = each.value
+  overwrite_on_create = true
+}
+
+resource "github_repository_file" "dotfiles" {
+  for_each = local.dotfiles
+
+  repository          = local.repo.name
+  branch              = local.repo.default_branch
+  file                = each.key
+  content             = each.value
+  overwrite_on_create = true
+
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
 resource "github_repository_file" "files_strict" {
-  for_each   = local.files_strict
-  depends_on = [github_actions_secret.secret]
+  for_each = local.files_strict
+  depends_on = [
+    github_actions_secret.secret,
+    github_repository_file.dotfiles_strict
+  ]
 
   repository          = local.repo.name
   branch              = local.repo.default_branch
@@ -25,8 +58,10 @@ resource "github_repository_file" "files_strict" {
 }
 
 resource "github_repository_file" "files" {
-  for_each   = local.files
-  depends_on = [github_actions_secret.secret]
+  for_each = local.files
+  depends_on = [github_actions_secret.secret,
+    github_repository_file.dotfiles
+  ]
 
   repository          = local.repo.name
   branch              = local.repo.default_branch


### PR DESCRIPTION
This is useful for creating GitHub Actions sync workflows first, and then add other files to the
configuration repo so they can be synced
